### PR TITLE
Python fixes (part 2)

### DIFF
--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -363,7 +363,9 @@ EOF
     #                returns char* so an implicit int decl would truncate it.
     #   getentropy - exists on OpenBSD but isn't declared here; CPython falls back
     #                to reading /dev/urandom for bootstrap_hash.
-    case "$TARGET" in *openbsd*) printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\n' >> config.site ;; esac
+    #   getthrid   - OpenBSD native-thread-id syscall; not declared in zig's headers;
+    #                CPython falls back to pthread_self() for the thread ID.
+    case "$TARGET" in *openbsd*) printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\nac_cv_func_getthrid=no\n' >> config.site ;; esac
     # linux/musl: force every extension module to be linked into the interpreter
     # (zig's musl is static-only -- it cannot produce the .so files setup.py would
     # otherwise emit, and -static + -shared is contradictory). CPython builds the

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -362,6 +362,19 @@ MODULE_BUILDTYPE=static
 ' configure ;;
       esac
     fi
+    # linux/bsd (zig): neuter setup.py's add_cross_compiling_paths(). It probes
+    # `$(CC) -E -v` and adds every "#include <...>" dir that isn't a /gcc/ or
+    # /clang/ path -- but zig's clang reports the host's /usr/include and
+    # /usr/local/include there, so those leak into the cross build. The host
+    # glibc <stdlib.h> then pulls <bits/libc-header-start.h> from the Debian
+    # multiarch dir zig never searches -> every extension fails to compile. zig
+    # resolves its own sysroot internally (not via -I), so the probe is pure
+    # downside here; drop it. macos/osxcross and windows/mingw report correct
+    # sysroots from the same probe, so they keep it.
+    case "$PLATFORM" in
+      linux|bsd) sed -i 's/^\( *\)def add_cross_compiling_paths(self):/\1def add_cross_compiling_paths(self):\n\1    return  # NDK: zig embeds its sysroot; host \/usr\/include must not leak in/' setup.py ;;
+    esac
+
     # Neutralise the build host's pkg-config (PKG_CONFIG=/bin/false). These are
     # cross builds, so a host pkg-config only ever reports x86_64-linux libs;
     # letting CPython's configure see it wrongly flips Makefile-built modules

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -407,9 +407,19 @@ MODULE_BUILDTYPE=static
               _PYTHON_HOST_PLATFORM="$TARGET" )
     fi
     case "$PLATFORM" in
-      bionic) args+=( TOOLCHAIN="$TC" API="$API"
+      bionic) # grp: bionic only declares/exports the getgrent/setgrent/endgrent
+              # family at API 26, but we target API $API, so grpmodule.c neither
+              # compiles (clang 22 errors on the implicit decls) nor links there.
+              # _ctypes_test: a test-only module that EXPORT()s data symbols;
+              # setup.py compiles bionic extensions without -fPIC, so those become
+              # preemptible in the .so and lld rejects the relocations. Mark both
+              # n/a so configure/setup.py skip them. (_ctypes itself is a setup.py
+              # module with no configure knob; it self-skips on missing ffi.h, as
+              # on every target.)
+              args+=( TOOLCHAIN="$TC" API="$API"
                       LD_LIBRARY_PATH="$TC/sysroot/usr/lib/$TARGET"
-                      LDFLAGS="-static-libstdc++ -static-libgcc" ) ;;
+                      LDFLAGS="-static-libstdc++ -static-libgcc"
+                      py_cv_module_grp=n/a py_cv_module__ctypes_test=n/a ) ;;
       linux)   args+=( CFLAGS="-Wno-error=date-time $CROSS_CFLAGS"
                       CXXFLAGS="-Wno-error=date-time $CROSS_CFLAGS"
                       LDFLAGS="$CROSS_LDFLAGS" ) ;;

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -361,8 +361,8 @@ EOF
     # which compiles to ___isPlatformVersionAtLeast (compiler-rt). osxcross
     # cross-links don't pull that in automatically; disable both to avoid it.
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
-    # OpenBSD: -D_GNU_SOURCE (CFLAGS above) makes zig/musl headers expose
-    # functions that are gated behind _GNU_SOURCE (wait4, strndup, ...).
+    # OpenBSD: -D_BSD_SOURCE (CFLAGS above) keeps __BSD_VISIBLE=1 even when
+    # CPython defines _POSIX_C_SOURCE, restoring BSD function visibility.
     # memrchr / getentropy: zig uses actual OpenBSD headers for OpenBSD targets
     # (not musl's), and those headers don't expose these symbols under the
     # feature-test macros zig emits.  Configure link tests still pass (symbols
@@ -459,17 +459,15 @@ MODULE_BUILDTYPE=static
               # "unknown" platform tag, so without this the .so links fail with
               # R_AARCH64_* "recompile with -fPIC". Making the whole build PIC is
               # harmless for a static host tool.
-              # OpenBSD via zig: for functions whose symbols exist in zig's
-              # bundled libc but whose prototypes are gated behind _GNU_SOURCE
-              # in zig/musl headers (wait4, strndup, ...), without this flag
-              # AC_CHECK_FUNCS would succeed, HAVE_X would be set, but the final
-              # compile would fire -Werror=implicit-function-declaration.
-              # Note: memrchr is NOT fixed by this — zig uses actual OpenBSD
-              # headers for OpenBSD targets and OpenBSD's <string.h> never
-              # declares memrchr; that is blocked via ac_cv_func_memrchr=no in
-              # config.site instead.  Linux-specific syscall wrappers are also
-              # blocked in config.site below.
-              local obsd=""; [ "$SYSTEM_NAME" = OpenBSD ] && obsd="-D_GNU_SOURCE"
+              # OpenBSD via zig: CPython (or its transitive headers) defines
+              # _POSIX_C_SOURCE, which causes OpenBSD's sys/cdefs.h to set
+              # __BSD_VISIBLE=0, hiding u_long (sys/types.h), chflags, wait3/4,
+              # dup3, pipe2, preadv/pwritev, getloadavg, etc.  The correct
+              # override is -D_BSD_SOURCE, which sys/cdefs.h recognises as an
+              # explicit opt-in to BSD visibility even when POSIX macros are set.
+              # _GNU_SOURCE has no effect on OpenBSD headers (it is not handled
+              # by sys/cdefs.h) and was removed.
+              local obsd=""; [ "$SYSTEM_NAME" = OpenBSD ] && obsd="-D_BSD_SOURCE"
               args+=( CFLAGS="-fPIC -Wno-error=date-time $obsd $CROSS_CFLAGS"
                       CXXFLAGS="-fPIC -Wno-error=date-time $obsd $CROSS_CFLAGS"
                       LDFLAGS="$CROSS_LDFLAGS" ) ;;

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -356,21 +356,22 @@ EOF
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
     # OpenBSD: -D_GNU_SOURCE (CFLAGS above) makes zig/musl headers expose
     # functions that are gated behind _GNU_SOURCE (wait4, strndup, ...).
-    # memrchr is a special case: zig uses actual OpenBSD headers for OpenBSD
-    # targets (not musl's), and OpenBSD's <string.h> never declares memrchr
-    # under any feature-test macro.  The configure link test still passes
-    # (the symbol is present in zig's bundled libc), so HAVE_MEMRCHR gets set,
-    # but fastsearch.h's call then fires -Werror=implicit-function-declaration.
-    # Force the cache var off so CPython uses its own fallback implementation.
+    # memrchr / getentropy: zig uses actual OpenBSD headers for OpenBSD targets
+    # (not musl's).  OpenBSD's <string.h> never declares memrchr and its
+    # <unistd.h> doesn't expose getentropy under the feature-test macros zig
+    # emits.  Both configure link tests still pass (the symbols exist in zig's
+    # bundled libc), so HAVE_* gets set, but the calls then fire
+    # -Werror=implicit-function-declaration.  Force them off so CPython uses
+    # its own fallbacks (pure-C memrchr loop; /dev/urandom for entropy).
     # Also block functions whose configure link test would pass but whose
     # runtime semantics are wrong on OpenBSD:
-    #   sendfile  — CPython's posixmodule.c only handles Linux/macOS/FreeBSD
-    #               variants; OpenBSD's sendfile(2) has BSD arguments and falls
-    #               through to the Linux path if HAVE_SENDFILE is set.
-    #   getrandom — Linux-specific syscall; OpenBSD uses getentropy(3) instead.
+    #   sendfile    — CPython's posixmodule.c only handles Linux/macOS/FreeBSD
+    #                 variants; OpenBSD's sendfile(2) has BSD arguments and
+    #                 falls through to the Linux path if HAVE_SENDFILE is set.
+    #   getrandom   — Linux-specific syscall; OpenBSD uses getentropy(3).
     #   posix_fadvise / posix_fallocate — absent from OpenBSD entirely.
     if [ "$SYSTEM_NAME" = OpenBSD ]; then
-      printf 'ac_cv_func_memrchr=no\nac_cv_func_sendfile=no\nac_cv_func_getrandom=no\nac_cv_func_posix_fadvise=no\nac_cv_func_posix_fallocate=no\n' >> config.site
+      printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\nac_cv_func_sendfile=no\nac_cv_func_getrandom=no\nac_cv_func_posix_fadvise=no\nac_cv_func_posix_fallocate=no\n' >> config.site
     fi
     # linux/musl: force every extension module to be linked into the interpreter
     # (zig's musl is static-only -- it cannot produce the .so files setup.py would

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -405,15 +405,26 @@ MODULE_BUILDTYPE=static
                # msys2 mingw-w64-python recipe). WINDRES compiles the PC/*.rc
                # resource files (python_nt.o etc., needed by the DLL/exe links);
                # llvm-mingw's bin is off PATH, so configure can't auto-detect it.
+               # -Wno-incompatible-pointer-types: clang 22 makes this diagnostic a
+               # hard error by default, but _multiprocessing/semaphore.c passes an
+               # int* to _GetSemaphoreValue(HANDLE, long*) on every mingw target;
+               # downgrade it so the extension (and any sibling) keeps building.
                local laa=""; [ "$TARGET" = i686-w64-mingw32 ] && laa=" -Wl,--large-address-aware"
                args+=( --enable-shared
-                       CFLAGS="-O2 -Wno-error=implicit-function-declaration -Wno-error=date-time"
-                       CXXFLAGS="-O2 -Wno-error=implicit-function-declaration -Wno-error=date-time"
+                       CFLAGS="-O2 -Wno-error=implicit-function-declaration -Wno-error=date-time -Wno-incompatible-pointer-types"
+                       CXXFLAGS="-O2 -Wno-error=implicit-function-declaration -Wno-error=date-time -Wno-incompatible-pointer-types"
                        LDFLAGS="-static-libstdc++ -static-libgcc$laa"
                        LDSHARED="$CROSS_CC -shared"
                        WINDRES="$TC/bin/${TARGET}-windres" ) ;;
     esac
     ./configure "${args[@]}"
+    # windows: the extension-module pass (sharedmods -> setup.py build) links each
+    # .pyd against -lpython3.11, but the Makefile's sharedmods rule has no
+    # dependency on the import library libpython3.11.dll.a (emitted as a side
+    # effect of the libpython3.11.dll link rule). Under -j that races -> a swarm
+    # of "lld: error: unable to find library -lpython3.11". Build the DLL (and
+    # thus its import lib) first so it always exists before the extensions link.
+    [ "$PLATFORM" = windows ] && make -j"$(ncpu)" libpython3.11.dll
     make -j"$(ncpu)" build_all
     make install
   )

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -429,21 +429,20 @@ MODULE_BUILDTYPE=static
       args+=( --disable-shared --disable-ipv6 LDSHARED="$CROSS_CC -shared -fPIC"
               _PYTHON_HOST_PLATFORM="$TARGET" )
     fi
+    # _ctypes_test: test-only module, never useful in an NDK host tool.
+    # _ctypes has no py_cv_module_ knob; it self-skips when ffi.h is absent,
+    # which is always the case here since libffi is never built.
+    args+=( py_cv_module__ctypes_test=n/a )
     case "$PLATFORM" in
       bionic) # grp: bionic only declares/exports the getgrent/setgrent/endgrent
               # family from API 26, so below that grpmodule.c neither compiles
               # (clang hard-errors the implicit decls) nor links -- mark it n/a
               # only when targeting < 26; at 26+ let it build normally.
-              # _ctypes_test: a test-only module that EXPORT()s data symbols, but
-              # setup.py compiles bionic extensions without -fPIC, so those become
-              # preemptible in the .so and lld rejects the relocations -- always
-              # skip. (_ctypes itself is a setup.py module with no configure knob;
-              # it self-skips on missing ffi.h, as on every target.)
               local grpna=""; [ "$API" -lt 26 ] && grpna="py_cv_module_grp=n/a"
               args+=( TOOLCHAIN="$TC" API="$API"
                       LD_LIBRARY_PATH="$TC/sysroot/usr/lib/$TARGET"
                       LDFLAGS="-static-libstdc++ -static-libgcc"
-                      py_cv_module__ctypes_test=n/a $grpna ) ;;
+                      $grpna ) ;;
       linux)   args+=( CFLAGS="-Wno-error=date-time $CROSS_CFLAGS"
                       CXXFLAGS="-Wno-error=date-time $CROSS_CFLAGS"
                       LDFLAGS="$CROSS_LDFLAGS" ) ;;

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -363,7 +363,7 @@ EOF
     #                returns char* so an implicit int decl would truncate it.
     #   getentropy - exists on OpenBSD but isn't declared here; CPython falls back
     #                to reading /dev/urandom for bootstrap_hash.
-    case "$TARGET" in *openbsd*) printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\n' >> config.site ;;
+    case "$TARGET" in *openbsd*) printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\n' >> config.site ;; esac
     # linux/musl: force every extension module to be linked into the interpreter
     # (zig's musl is static-only -- it cannot produce the .so files setup.py would
     # otherwise emit, and -static + -shared is contradictory). CPython builds the

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -384,7 +384,8 @@ MODULE_BUILDTYPE=static
     # downside here; drop it. macos/osxcross and windows/mingw report correct
     # sysroots from the same probe, so they keep it.
     case "$PLATFORM" in
-      linux|bsd) sed -i 's/^\( *\)def add_cross_compiling_paths(self):/\1def add_cross_compiling_paths(self):\n\1    return  # NDK: zig embeds its sysroot; host \/usr\/include must not leak in/' setup.py ;;
+      linux) sed -i 's/^\( *\)def add_cross_compiling_paths(self):/\1def add_cross_compiling_paths(self):\n\1    return  # NDK: zig embeds its sysroot; host \/usr\/include must not leak in/' setup.py ;;
+      bsd) [ "$SYSTEM_NAME" != "OpenBSD" ] && sed -i 's/^\( *\)def add_cross_compiling_paths(self):/\1def add_cross_compiling_paths(self):\n\1    return  # NDK: zig embeds its sysroot; host \/usr\/include must not leak in/' setup.py ;;
     esac
 
     # Neutralise the build host's pkg-config (PKG_CONFIG=/bin/false). These are

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -354,20 +354,23 @@ EOF
     # which compiles to ___isPlatformVersionAtLeast (compiler-rt). osxcross
     # cross-links don't pull that in automatically; disable both to avoid it.
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
-    # OpenBSD: -D_GNU_SOURCE (CFLAGS above) fixes the whole class of "musl has
-    # the symbol but its header gates the prototype behind _GNU_SOURCE" errors
-    # (memrchr, wait4, ...) by making those prototypes visible.  What still
-    # needs to be blocked here are functions whose configure link test would
-    # pass but whose runtime semantics are wrong on OpenBSD because zig/musl
-    # exposes a Linux-specific syscall wrapper with a different ABI or a stub
-    # that would fail at runtime:
-    #   sendfile  â€“ CPython's posixmodule.c only handles Linux/macOS/FreeBSD
+    # OpenBSD: -D_GNU_SOURCE (CFLAGS above) makes zig/musl headers expose
+    # functions that are gated behind _GNU_SOURCE (wait4, strndup, ...).
+    # memrchr is a special case: zig uses actual OpenBSD headers for OpenBSD
+    # targets (not musl's), and OpenBSD's <string.h> never declares memrchr
+    # under any feature-test macro.  The configure link test still passes
+    # (the symbol is present in zig's bundled libc), so HAVE_MEMRCHR gets set,
+    # but fastsearch.h's call then fires -Werror=implicit-function-declaration.
+    # Force the cache var off so CPython uses its own fallback implementation.
+    # Also block functions whose configure link test would pass but whose
+    # runtime semantics are wrong on OpenBSD:
+    #   sendfile  â€” CPython's posixmodule.c only handles Linux/macOS/FreeBSD
     #               variants; OpenBSD's sendfile(2) has BSD arguments and falls
     #               through to the Linux path if HAVE_SENDFILE is set.
-    #   getrandom â€“ Linux-specific syscall; OpenBSD uses getentropy(3) instead.
-    #   posix_fadvise / posix_fallocate â€“ absent from OpenBSD entirely.
-    if [ "$SYSTEM_NAME" = OpenBSD ]; then
-      printf 'ac_cv_func_sendfile=no\nac_cv_func_getrandom=no\nac_cv_func_posix_fadvise=no\nac_cv_func_posix_fallocate=no\n' >> config.site
+    #   getrandom â€” Linux-specific syscall; OpenBSD uses getentropy(3) instead.
+    #   posix_fadvise / posix_fallocate â€” absent from OpenBSD entirely.
+    if [ “$SYSTEM_NAME” = OpenBSD ]; then
+      printf 'ac_cv_func_memrchr=no\nac_cv_func_sendfile=no\nac_cv_func_getrandom=no\nac_cv_func_posix_fadvise=no\nac_cv_func_posix_fallocate=no\n' >> config.site
     fi
     # linux/musl: force every extension module to be linked into the interpreter
     # (zig's musl is static-only -- it cannot produce the .so files setup.py would
@@ -446,16 +449,16 @@ MODULE_BUILDTYPE=static
               # "unknown" platform tag, so without this the .so links fail with
               # R_AARCH64_* "recompile with -fPIC". Making the whole build PIC is
               # harmless for a static host tool.
-              # OpenBSD via zig: zig uses a musl-based libc whose headers gate
-              # many functions (wait4, memrchr, strndup, ...) behind _GNU_SOURCE.
-              # Without this, AC_CHECK_FUNCS link tests succeed (the symbol exists
-              # in musl), HAVE_X is set, but the final compile fires
-              # -Werror=implicit-function-declaration because the prototype is
-              # absent from the headers.  -D_DARWIN_C_SOURCE plays the same role
-              # for macOS.  The functions enabled by this are pure C library
-              # routines statically linked from musl, so there is no syscall-ABI
-              # concern; Linux-specific syscall wrappers are blocked separately
-              # in config.site below.
+              # OpenBSD via zig: for functions whose symbols exist in zig's
+              # bundled libc but whose prototypes are gated behind _GNU_SOURCE
+              # in zig/musl headers (wait4, strndup, ...), without this flag
+              # AC_CHECK_FUNCS would succeed, HAVE_X would be set, but the final
+              # compile would fire -Werror=implicit-function-declaration.
+              # Note: memrchr is NOT fixed by this — zig uses actual OpenBSD
+              # headers for OpenBSD targets and OpenBSD's <string.h> never
+              # declares memrchr; that is blocked via ac_cv_func_memrchr=no in
+              # config.site instead.  Linux-specific syscall wrappers are also
+              # blocked in config.site below.
               local obsd=""; [ "$SYSTEM_NAME" = OpenBSD ] && obsd="-D_GNU_SOURCE"
               args+=( CFLAGS="-fPIC -Wno-error=date-time $obsd $CROSS_CFLAGS"
                       CXXFLAGS="-fPIC -Wno-error=date-time $obsd $CROSS_CFLAGS"

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -356,16 +356,19 @@ EOF
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
     # openbsd: zig's bundled OpenBSD libc headers under-declare functions whose
     # symbols it nonetheless exports, so configure's link tests set HAVE_* but the
-    # call sites are implicit decls that clang 22 turns into hard errors, killing
+    # call sites are implicit decls that clang turns into hard errors, killing
     # the core build. Force each such cache var off so CPython uses its portable
     # fallback:
     #   memrchr    - a glibc/BSD-but-not-OpenBSD extension (<string.h>); also
     #                returns char* so an implicit int decl would truncate it.
     #   getentropy - exists on OpenBSD but isn't declared here; CPython falls back
     #                to reading /dev/urandom for bootstrap_hash.
-    #   getthrid   - OpenBSD native-thread-id syscall; not declared in zig's headers;
-    #                CPython falls back to pthread_self() for the thread ID.
-    case "$TARGET" in *openbsd*) printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\nac_cv_func_getthrid=no\n' >> config.site ;; esac
+    case "$TARGET" in *openbsd*) printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\n' >> config.site ;; esac
+    # getthrid() cannot be suppressed via config.site: configure has no
+    # AC_CHECK_FUNC(getthrid) check, so thread_pthread.h calls it unconditionally
+    # inside #elif defined(__OpenBSD__) with no HAVE_GETTHRID guard. Inject a
+    # forward declaration at the call site to satisfy clang.
+    case "$TARGET" in *openbsd*) sed -i 's/    native_id = getthrid();/    { extern pid_t getthrid(void); native_id = (unsigned long)getthrid(); }/' Python/thread_pthread.h ;; esac
     # linux/musl: force every extension module to be linked into the interpreter
     # (zig's musl is static-only -- it cannot produce the .so files setup.py would
     # otherwise emit, and -static + -shared is contradictory). CPython builds the
@@ -421,7 +424,7 @@ MODULE_BUILDTYPE=static
     case "$PLATFORM" in
       bionic) # grp: bionic only declares/exports the getgrent/setgrent/endgrent
               # family from API 26, so below that grpmodule.c neither compiles
-              # (clang 22 hard-errors the implicit decls) nor links -- mark it n/a
+              # (clang hard-errors the implicit decls) nor links -- mark it n/a
               # only when targeting < 26; at 26+ let it build normally.
               # _ctypes_test: a test-only module that EXPORT()s data symbols, but
               # setup.py compiles bionic extensions without -fPIC, so those become
@@ -460,7 +463,7 @@ MODULE_BUILDTYPE=static
                # msys2 mingw-w64-python recipe). WINDRES compiles the PC/*.rc
                # resource files (python_nt.o etc., needed by the DLL/exe links);
                # llvm-mingw's bin is off PATH, so configure can't auto-detect it.
-               # -Wno-incompatible-pointer-types: clang 22 makes this diagnostic a
+               # -Wno-incompatible-pointer-types: clang makes this diagnostic a
                # hard error by default, but _multiprocessing/semaphore.c passes an
                # int* to _GetSemaphoreValue(HANDLE, long*) on every mingw target;
                # downgrade it so the extension (and any sibling) keeps building.

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -354,12 +354,16 @@ EOF
     # which compiles to ___isPlatformVersionAtLeast (compiler-rt). osxcross
     # cross-links don't pull that in automatically; disable both to avoid it.
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
-    # openbsd: memrchr is a glibc/*BSD-but-not-OpenBSD extension. zig's bundled
-    # libc exposes the symbol so configure's link test sets HAVE_MEMRCHR, but
-    # OpenBSD's <string.h> never declares it -> fastsearch.h's memrchr() call is
-    # an implicit decl, which clang 22 makes a hard error (plus int->pointer) and
-    # kills the core build. Force the cache var off so CPython uses its fallback.
-    case "$TARGET" in *openbsd*) printf 'ac_cv_func_memrchr=no\n' >> config.site ;; esac
+    # openbsd: zig's bundled OpenBSD libc headers under-declare functions whose
+    # symbols it nonetheless exports, so configure's link tests set HAVE_* but the
+    # call sites are implicit decls that clang 22 turns into hard errors, killing
+    # the core build. Force each such cache var off so CPython uses its portable
+    # fallback:
+    #   memrchr    - a glibc/BSD-but-not-OpenBSD extension (<string.h>); also
+    #                returns char* so an implicit int decl would truncate it.
+    #   getentropy - exists on OpenBSD but isn't declared here; CPython falls back
+    #                to reading /dev/urandom for bootstrap_hash.
+    case "$TARGET" in *openbsd*) printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\n' >> config.site ;;
     # linux/musl: force every extension module to be linked into the interpreter
     # (zig's musl is static-only -- it cannot produce the .so files setup.py would
     # otherwise emit, and -static + -shared is contradictory). CPython builds the

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -462,10 +462,14 @@ MODULE_BUILDTYPE=static
               # explicit opt-in to BSD visibility even when POSIX macros are set.
               # _GNU_SOURCE has no effect on OpenBSD headers (it is not handled
               # by sys/cdefs.h) and was removed.
-              local obsd=""; [ "$SYSTEM_NAME" = OpenBSD ] && obsd="-D_BSD_SOURCE"
+              # nis: OpenBSD removed YP/NIS support, so zig ships no
+              # rpcsvc/yp_prot.h and nismodule.c can't compile. Mark it n/a only
+              # for OpenBSD; FreeBSD/NetBSD still provide the rpcsvc headers.
+              local obsd="" nisna=""
+              if [ "$SYSTEM_NAME" = OpenBSD ]; then obsd="-D_BSD_SOURCE"; nisna="py_cv_module_nis=n/a"; fi
               args+=( CFLAGS="-fPIC -Wno-error=date-time $obsd $CROSS_CFLAGS"
                       CXXFLAGS="-fPIC -Wno-error=date-time $obsd $CROSS_CFLAGS"
-                      LDFLAGS="$CROSS_LDFLAGS" ) ;;
+                      LDFLAGS="$CROSS_LDFLAGS" $nisna ) ;;
       macos)  # _DARWIN_C_SOURCE: expose BSD extensions masked by _POSIX_C_SOURCE
               #   (needed so sendfile() is declared; -Wno-error alone won't help
               #   because Python re-appends -Werror=implicit-function-declaration).

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -364,12 +364,12 @@ EOF
     # Force the cache var off so CPython uses its own fallback implementation.
     # Also block functions whose configure link test would pass but whose
     # runtime semantics are wrong on OpenBSD:
-    #   sendfile  â€” CPython's posixmodule.c only handles Linux/macOS/FreeBSD
+    #   sendfile  — CPython's posixmodule.c only handles Linux/macOS/FreeBSD
     #               variants; OpenBSD's sendfile(2) has BSD arguments and falls
     #               through to the Linux path if HAVE_SENDFILE is set.
-    #   getrandom â€” Linux-specific syscall; OpenBSD uses getentropy(3) instead.
-    #   posix_fadvise / posix_fallocate â€” absent from OpenBSD entirely.
-    if [ “$SYSTEM_NAME” = OpenBSD ]; then
+    #   getrandom — Linux-specific syscall; OpenBSD uses getentropy(3) instead.
+    #   posix_fadvise / posix_fallocate — absent from OpenBSD entirely.
+    if [ "$SYSTEM_NAME" = OpenBSD ]; then
       printf 'ac_cv_func_memrchr=no\nac_cv_func_sendfile=no\nac_cv_func_getrandom=no\nac_cv_func_posix_fadvise=no\nac_cv_func_posix_fallocate=no\n' >> config.site
     fi
     # linux/musl: force every extension module to be linked into the interpreter

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -363,24 +363,19 @@ EOF
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
     # OpenBSD: -D_BSD_SOURCE (CFLAGS above) keeps __BSD_VISIBLE=1 even when
     # CPython defines _POSIX_C_SOURCE, restoring BSD function visibility.
-    # memrchr / getentropy: zig uses actual OpenBSD headers for OpenBSD targets
-    # (not musl's), and those headers don't expose these symbols under the
-    # feature-test macros zig emits.  Configure link tests still pass (symbols
-    # present in zig's bundled libc), so HAVE_* gets set, but the bare calls
-    # fire -Werror=implicit-function-declaration.  Force them off so CPython
-    # uses its own fallbacks (pure-C memrchr loop; /dev/urandom for entropy).
-    # getthrid is handled differently: thread_pthread.h guards it with
-    # #ifdef __OpenBSD__ (not HAVE_GETTHRID), so config.site has no effect;
-    # a forward declaration is injected into the source above instead.
-    # Also block functions whose configure link test would pass but whose
-    # runtime semantics are wrong on OpenBSD:
+    # memrchr: OpenBSD's <string.h> never declares it even with __BSD_VISIBLE=1
+    # — it is simply absent from OpenBSD's libc interface.  The configure link
+    # test passes (symbol present in zig's bundled libc from musl), so force
+    # the cache var off so CPython uses its own pure-C fallback.
+    # Block functions whose configure link test passes but whose runtime
+    # semantics are wrong on OpenBSD:
     #   sendfile    — CPython's posixmodule.c only handles Linux/macOS/FreeBSD
     #                 variants; OpenBSD's sendfile(2) has BSD arguments and
     #                 falls through to the Linux path if HAVE_SENDFILE is set.
     #   getrandom   — Linux-specific syscall; OpenBSD uses getentropy(3).
     #   posix_fadvise / posix_fallocate — absent from OpenBSD entirely.
     if [ "$SYSTEM_NAME" = OpenBSD ]; then
-      printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\nac_cv_func_getthrid=no\nac_cv_func_sendfile=no\nac_cv_func_getrandom=no\nac_cv_func_posix_fadvise=no\nac_cv_func_posix_fallocate=no\n' >> config.site
+      printf 'ac_cv_func_memrchr=no\nac_cv_func_sendfile=no\nac_cv_func_getrandom=no\nac_cv_func_posix_fadvise=no\nac_cv_func_posix_fallocate=no\n' >> config.site
     fi
     # linux/musl: force every extension module to be linked into the interpreter
     # (zig's musl is static-only -- it cannot produce the .so files setup.py would

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -354,6 +354,12 @@ EOF
     # which compiles to ___isPlatformVersionAtLeast (compiler-rt). osxcross
     # cross-links don't pull that in automatically; disable both to avoid it.
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
+    # openbsd: memrchr is a glibc/*BSD-but-not-OpenBSD extension. zig's bundled
+    # libc exposes the symbol so configure's link test sets HAVE_MEMRCHR, but
+    # OpenBSD's <string.h> never declares it -> fastsearch.h's memrchr() call is
+    # an implicit decl, which clang 22 makes a hard error (plus int->pointer) and
+    # kills the core build. Force the cache var off so CPython uses its fallback.
+    case "$TARGET" in *openbsd*) printf 'ac_cv_func_memrchr=no\n' >> config.site ;; esac
     # linux/musl: force every extension module to be linked into the interpreter
     # (zig's musl is static-only -- it cannot produce the .so files setup.py would
     # otherwise emit, and -static + -shared is contradictory). CPython builds the
@@ -424,7 +430,14 @@ MODULE_BUILDTYPE=static
       linux)   args+=( CFLAGS="-Wno-error=date-time $CROSS_CFLAGS"
                       CXXFLAGS="-Wno-error=date-time $CROSS_CFLAGS"
                       LDFLAGS="$CROSS_LDFLAGS" ) ;;
-      bsd)    args+=( CFLAGS="-Wno-error=date-time $CROSS_CFLAGS" CXXFLAGS="-Wno-error=date-time $CROSS_CFLAGS"
+      bsd)    # -fPIC: bsd keeps a static libpython but setup.py still emits the
+              # stdlib extensions as shared .so, and they reference external
+              # preemptible data (PyExc_*, type objects, _Py_NoneStruct) that needs
+              # GOT indirection. configure doesn't set CCSHARED=-fPIC for the
+              # "unknown" platform tag, so without this the .so links fail with
+              # R_AARCH64_* "recompile with -fPIC". Making the whole build PIC is
+              # harmless for a static host tool.
+              args+=( CFLAGS="-fPIC -Wno-error=date-time $CROSS_CFLAGS" CXXFLAGS="-fPIC -Wno-error=date-time $CROSS_CFLAGS"
                       LDFLAGS="$CROSS_LDFLAGS" ) ;;
       macos)  # _DARWIN_C_SOURCE: expose BSD extensions masked by _POSIX_C_SOURCE
               #   (needed so sendfile() is declared; -Wno-error alone won't help

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -354,12 +354,24 @@ EOF
     # which compiles to ___isPlatformVersionAtLeast (compiler-rt). osxcross
     # cross-links don't pull that in automatically; disable both to avoid it.
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
-    # linux: force static extension modules
+    # linux/musl: force every extension module to be linked into the interpreter
+    # (zig's musl is static-only -- it cannot produce the .so files setup.py would
+    # otherwise emit, and -static + -shared is contradictory). CPython builds the
+    # stdlib extensions via makesetup+Modules/Setup.stdlib only when
+    # MODULES_SETUP_STDLIB points at it, which configure does solely for
+    # Emscripten/WASI; every other host leaves it empty and the modules fall
+    # through to setup.py as shared .so. So (1) force MODULE_BUILDTYPE=static (the
+    # *static* marker makesetup honours) and (2) activate Setup.stdlib for this
+    # host too, matching the wasm static path. setup.py then skips the
+    # makesetup-built modules, so nothing is built shared.
     if [ "$PLATFORM" = linux ]; then
       case "$TARGET" in
-        *musl*) sed -i '/^case \$host_cpu in #(/,/^esac$/c\
+        *musl*)
+          sed -i '/^case \$host_cpu in #(/,/^esac$/c\
 MODULE_BUILDTYPE=static
-' configure ;;
+' configure
+          sed -i 's#^\([[:space:]]*\)MODULES_SETUP_STDLIB=$#\1MODULES_SETUP_STDLIB=Modules/Setup.stdlib#' configure
+          ;;
       esac
     fi
     # linux/bsd (zig): neuter setup.py's add_cross_compiling_paths(). It probes

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -408,18 +408,19 @@ MODULE_BUILDTYPE=static
     fi
     case "$PLATFORM" in
       bionic) # grp: bionic only declares/exports the getgrent/setgrent/endgrent
-              # family at API 26, but we target API $API, so grpmodule.c neither
-              # compiles (clang 22 errors on the implicit decls) nor links there.
-              # _ctypes_test: a test-only module that EXPORT()s data symbols;
+              # family from API 26, so below that grpmodule.c neither compiles
+              # (clang 22 hard-errors the implicit decls) nor links -- mark it n/a
+              # only when targeting < 26; at 26+ let it build normally.
+              # _ctypes_test: a test-only module that EXPORT()s data symbols, but
               # setup.py compiles bionic extensions without -fPIC, so those become
-              # preemptible in the .so and lld rejects the relocations. Mark both
-              # n/a so configure/setup.py skip them. (_ctypes itself is a setup.py
-              # module with no configure knob; it self-skips on missing ffi.h, as
-              # on every target.)
+              # preemptible in the .so and lld rejects the relocations -- always
+              # skip. (_ctypes itself is a setup.py module with no configure knob;
+              # it self-skips on missing ffi.h, as on every target.)
+              local grpna=""; [ "$API" -lt 26 ] && grpna="py_cv_module_grp=n/a"
               args+=( TOOLCHAIN="$TC" API="$API"
                       LD_LIBRARY_PATH="$TC/sysroot/usr/lib/$TARGET"
                       LDFLAGS="-static-libstdc++ -static-libgcc"
-                      py_cv_module_grp=n/a py_cv_module__ctypes_test=n/a ) ;;
+                      py_cv_module__ctypes_test=n/a $grpna ) ;;
       linux)   args+=( CFLAGS="-Wno-error=date-time $CROSS_CFLAGS"
                       CXXFLAGS="-Wno-error=date-time $CROSS_CFLAGS"
                       LDFLAGS="$CROSS_LDFLAGS" ) ;;

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -354,21 +354,6 @@ EOF
     # which compiles to ___isPlatformVersionAtLeast (compiler-rt). osxcross
     # cross-links don't pull that in automatically; disable both to avoid it.
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
-    # openbsd: zig's bundled OpenBSD libc headers under-declare functions whose
-    # symbols it nonetheless exports, so configure's link tests set HAVE_* but the
-    # call sites are implicit decls that clang turns into hard errors, killing
-    # the core build. Force each such cache var off so CPython uses its portable
-    # fallback:
-    #   memrchr    - a glibc/BSD-but-not-OpenBSD extension (<string.h>); also
-    #                returns char* so an implicit int decl would truncate it.
-    #   getentropy - exists on OpenBSD but isn't declared here; CPython falls back
-    #                to reading /dev/urandom for bootstrap_hash.
-    case "$TARGET" in *openbsd*) printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\n' >> config.site ;; esac
-    # getthrid() cannot be suppressed via config.site: configure has no
-    # AC_CHECK_FUNC(getthrid) check, so thread_pthread.h calls it unconditionally
-    # inside #elif defined(__OpenBSD__) with no HAVE_GETTHRID guard. Inject a
-    # forward declaration at the call site to satisfy clang.
-    case "$TARGET" in *openbsd*) sed -i 's/    native_id = getthrid();/    { extern pid_t getthrid(void); native_id = (unsigned long)getthrid(); }/' Python/thread_pthread.h ;; esac
     # linux/musl: force every extension module to be linked into the interpreter
     # (zig's musl is static-only -- it cannot produce the .so files setup.py would
     # otherwise emit, and -static + -shared is contradictory). CPython builds the

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -356,13 +356,13 @@ EOF
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
     # OpenBSD: -D_GNU_SOURCE (CFLAGS above) makes zig/musl headers expose
     # functions that are gated behind _GNU_SOURCE (wait4, strndup, ...).
-    # memrchr / getentropy: zig uses actual OpenBSD headers for OpenBSD targets
-    # (not musl's).  OpenBSD's <string.h> never declares memrchr and its
-    # <unistd.h> doesn't expose getentropy under the feature-test macros zig
-    # emits.  Both configure link tests still pass (the symbols exist in zig's
-    # bundled libc), so HAVE_* gets set, but the calls then fire
-    # -Werror=implicit-function-declaration.  Force them off so CPython uses
-    # its own fallbacks (pure-C memrchr loop; /dev/urandom for entropy).
+    # memrchr / getentropy / getthrid: zig uses actual OpenBSD headers for
+    # OpenBSD targets (not musl's), and those headers don't expose these
+    # symbols under the feature-test macros zig emits.  Configure link tests
+    # still pass (symbols present in zig's bundled libc), so HAVE_* gets set,
+    # but the bare calls then fire -Werror=implicit-function-declaration.
+    # Force them off so CPython uses its own fallbacks (pure-C memrchr loop;
+    # /dev/urandom for entropy; pthread_self() cast for the thread id).
     # Also block functions whose configure link test would pass but whose
     # runtime semantics are wrong on OpenBSD:
     #   sendfile    — CPython's posixmodule.c only handles Linux/macOS/FreeBSD
@@ -371,7 +371,7 @@ EOF
     #   getrandom   — Linux-specific syscall; OpenBSD uses getentropy(3).
     #   posix_fadvise / posix_fallocate — absent from OpenBSD entirely.
     if [ "$SYSTEM_NAME" = OpenBSD ]; then
-      printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\nac_cv_func_sendfile=no\nac_cv_func_getrandom=no\nac_cv_func_posix_fadvise=no\nac_cv_func_posix_fallocate=no\n' >> config.site
+      printf 'ac_cv_func_memrchr=no\nac_cv_func_getentropy=no\nac_cv_func_getthrid=no\nac_cv_func_sendfile=no\nac_cv_func_getrandom=no\nac_cv_func_posix_fadvise=no\nac_cv_func_posix_fallocate=no\n' >> config.site
     fi
     # linux/musl: force every extension module to be linked into the interpreter
     # (zig's musl is static-only -- it cannot produce the .so files setup.py would

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -112,7 +112,7 @@ setup_toolchain() {
       # prefixed name (<triple>-ld) instead of falling through to the host
       # /usr/bin/ld. CMake's compiler-probe try-compiles don't honor
       # CMAKE_EXE_LINKER_FLAGS, so a -fuse-ld/--ld-path flag alone wouldn't reach
-      # them — PATH-based discovery covers every link uniformly.
+      # them, PATH-based discovery covers every link uniformly.
       export PATH="$TC/bin:$PATH"
       case "$TARGET" in
         arm64e-*)          ARCH=arm64e ;;   # distinct PAC ABI, not arm64
@@ -354,6 +354,21 @@ EOF
     # which compiles to ___isPlatformVersionAtLeast (compiler-rt). osxcross
     # cross-links don't pull that in automatically; disable both to avoid it.
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
+    # OpenBSD: -D_GNU_SOURCE (CFLAGS above) fixes the whole class of "musl has
+    # the symbol but its header gates the prototype behind _GNU_SOURCE" errors
+    # (memrchr, wait4, ...) by making those prototypes visible.  What still
+    # needs to be blocked here are functions whose configure link test would
+    # pass but whose runtime semantics are wrong on OpenBSD because zig/musl
+    # exposes a Linux-specific syscall wrapper with a different ABI or a stub
+    # that would fail at runtime:
+    #   sendfile  â€“ CPython's posixmodule.c only handles Linux/macOS/FreeBSD
+    #               variants; OpenBSD's sendfile(2) has BSD arguments and falls
+    #               through to the Linux path if HAVE_SENDFILE is set.
+    #   getrandom â€“ Linux-specific syscall; OpenBSD uses getentropy(3) instead.
+    #   posix_fadvise / posix_fallocate â€“ absent from OpenBSD entirely.
+    if [ "$SYSTEM_NAME" = OpenBSD ]; then
+      printf 'ac_cv_func_sendfile=no\nac_cv_func_getrandom=no\nac_cv_func_posix_fadvise=no\nac_cv_func_posix_fallocate=no\n' >> config.site
+    fi
     # linux/musl: force every extension module to be linked into the interpreter
     # (zig's musl is static-only -- it cannot produce the .so files setup.py would
     # otherwise emit, and -static + -shared is contradictory). CPython builds the
@@ -431,7 +446,19 @@ MODULE_BUILDTYPE=static
               # "unknown" platform tag, so without this the .so links fail with
               # R_AARCH64_* "recompile with -fPIC". Making the whole build PIC is
               # harmless for a static host tool.
-              args+=( CFLAGS="-fPIC -Wno-error=date-time $CROSS_CFLAGS" CXXFLAGS="-fPIC -Wno-error=date-time $CROSS_CFLAGS"
+              # OpenBSD via zig: zig uses a musl-based libc whose headers gate
+              # many functions (wait4, memrchr, strndup, ...) behind _GNU_SOURCE.
+              # Without this, AC_CHECK_FUNCS link tests succeed (the symbol exists
+              # in musl), HAVE_X is set, but the final compile fires
+              # -Werror=implicit-function-declaration because the prototype is
+              # absent from the headers.  -D_DARWIN_C_SOURCE plays the same role
+              # for macOS.  The functions enabled by this are pure C library
+              # routines statically linked from musl, so there is no syscall-ABI
+              # concern; Linux-specific syscall wrappers are blocked separately
+              # in config.site below.
+              local obsd=""; [ "$SYSTEM_NAME" = OpenBSD ] && obsd="-D_GNU_SOURCE"
+              args+=( CFLAGS="-fPIC -Wno-error=date-time $obsd $CROSS_CFLAGS"
+                      CXXFLAGS="-fPIC -Wno-error=date-time $obsd $CROSS_CFLAGS"
                       LDFLAGS="$CROSS_LDFLAGS" ) ;;
       macos)  # _DARWIN_C_SOURCE: expose BSD extensions masked by _POSIX_C_SOURCE
               #   (needed so sendfile() is declared; -Wno-error alone won't help

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -313,6 +313,13 @@ build_python() {
     # the bsd configure carries the Darwin cross-build fixups too (darwin was
     # built through the bsd path before it moved to its own osxcross platform)
     case "$PLATFORM" in bsd|macos) cp "$ROOT/patches/bsd/python/configure" "$PWD/configure" ;; esac
+    # OpenBSD: thread_pthread.h uses `#ifdef __OpenBSD__` (not HAVE_GETTHRID)
+    # to call getthrid(), so config.site can't suppress it.  zig's OpenBSD
+    # headers don't expose getthrid() transitively, so inject a forward
+    # declaration before the call site to satisfy -Werror=implicit-function-declaration.
+    if [ "$SYSTEM_NAME" = OpenBSD ]; then
+      sed -i 's|#elif defined(__OpenBSD__)|#elif defined(__OpenBSD__)\n    extern pid_t getthrid(void); /* not in zig cross headers */|' Python/thread_pthread.h
+    fi
     # windows: regenerate configure (+ pyconfig.h.in) from the patched
     # configure.ac (needs autoconf-archive + pkg.m4, baked into the build image)
     [ "$PLATFORM" = windows ] && autoreconf -vfi
@@ -356,13 +363,15 @@ EOF
     [ "$PLATFORM" = macos ] && printf 'ac_cv_func_sendfile=no\nac_cv_func_mkfifoat=no\nac_cv_func_mknodat=no\n' >> config.site
     # OpenBSD: -D_GNU_SOURCE (CFLAGS above) makes zig/musl headers expose
     # functions that are gated behind _GNU_SOURCE (wait4, strndup, ...).
-    # memrchr / getentropy / getthrid: zig uses actual OpenBSD headers for
-    # OpenBSD targets (not musl's), and those headers don't expose these
-    # symbols under the feature-test macros zig emits.  Configure link tests
-    # still pass (symbols present in zig's bundled libc), so HAVE_* gets set,
-    # but the bare calls then fire -Werror=implicit-function-declaration.
-    # Force them off so CPython uses its own fallbacks (pure-C memrchr loop;
-    # /dev/urandom for entropy; pthread_self() cast for the thread id).
+    # memrchr / getentropy: zig uses actual OpenBSD headers for OpenBSD targets
+    # (not musl's), and those headers don't expose these symbols under the
+    # feature-test macros zig emits.  Configure link tests still pass (symbols
+    # present in zig's bundled libc), so HAVE_* gets set, but the bare calls
+    # fire -Werror=implicit-function-declaration.  Force them off so CPython
+    # uses its own fallbacks (pure-C memrchr loop; /dev/urandom for entropy).
+    # getthrid is handled differently: thread_pthread.h guards it with
+    # #ifdef __OpenBSD__ (not HAVE_GETTHRID), so config.site has no effect;
+    # a forward declaration is injected into the source above instead.
     # Also block functions whose configure link test would pass but whose
     # runtime semantics are wrong on OpenBSD:
     #   sendfile    — CPython's posixmodule.c only handles Linux/macOS/FreeBSD

--- a/scripts/make-ndk.sh
+++ b/scripts/make-ndk.sh
@@ -384,8 +384,7 @@ MODULE_BUILDTYPE=static
     # downside here; drop it. macos/osxcross and windows/mingw report correct
     # sysroots from the same probe, so they keep it.
     case "$PLATFORM" in
-      linux) sed -i 's/^\( *\)def add_cross_compiling_paths(self):/\1def add_cross_compiling_paths(self):\n\1    return  # NDK: zig embeds its sysroot; host \/usr\/include must not leak in/' setup.py ;;
-      bsd) [ "$SYSTEM_NAME" != "OpenBSD" ] && sed -i 's/^\( *\)def add_cross_compiling_paths(self):/\1def add_cross_compiling_paths(self):\n\1    return  # NDK: zig embeds its sysroot; host \/usr\/include must not leak in/' setup.py ;;
+      linux|bsd) sed -i 's/^\( *\)def add_cross_compiling_paths(self):/\1def add_cross_compiling_paths(self):\n\1    return  # NDK: zig embeds its sysroot; host \/usr\/include must not leak in/' setup.py ;;
     esac
 
     # Neutralise the build host's pkg-config (PKG_CONFIG=/bin/false). These are


### PR DESCRIPTION
Opens the `python-fixes-part-2` branch from the `HomuHomu833-garbage/android-ndk-custom-experimental` fork into `main`.

https://claude.ai/code/session_011NMNhvMndAEChMfFDhFUm5

---
_Generated by [Claude Code](https://claude.ai/code/session_011NMNhvMndAEChMfFDhFUm5)_